### PR TITLE
First cut of resource pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ formatting responses.
 This example exposes the following endpoints:
 
 * GET    /v1/posts/
+* GET    /v1/posts/?page=1&size=100
 * GET    /v1/posts/?filter[title]=elixir
 * GET    /v1/posts/:id
 * POST   /v1/posts

--- a/test/relax/resource/fetch_all_test.exs
+++ b/test/relax/resource/fetch_all_test.exs
@@ -83,4 +83,12 @@ defmodule Relax.Resource.FetchAllTest do
     json = Poison.decode!(json, keys: :atoms)
     assert [%{created: 3}, %{created: 1}, %{created: 2}] = json
   end
+
+  test "paginate by 1" do
+    conn = Plug.Test.conn("GET", "/?page=1&size=1", [])
+            |> Plug.Conn.fetch_query_params
+    %{resp_body: json} = ArticlesResource.fetch_all_resources(conn)
+    json = Poison.decode!(json, keys: :atoms)
+    assert [%{created: 1, published: true, title: "one"}] = json
+  end
 end


### PR DESCRIPTION
Hello there, 

In this PR I added two cases for paginating `Ecto.Query` and `enumerables` but there are remain work around link http://jsonapi.org/format/#fetching-pagination and writing unit-tests using  `Ecto`. WDYT?
